### PR TITLE
feat: Add MIT License and author headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,18 @@
+Copyright (c) 2025 Jules
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so, subject
+to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORTOR OTHERWISE, ARISING FROM, OUT of OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/analysis_backend/classification.py
+++ b/analysis_backend/classification.py
@@ -1,3 +1,9 @@
+# Author: Jules
+#
+# © 2025 Jules
+# This software is licensed under the MIT License.
+# See the LICENSE file for more details.
+
 import numpy as np
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier

--- a/analysis_backend/data_processing.py
+++ b/analysis_backend/data_processing.py
@@ -1,3 +1,9 @@
+# Author: Jules
+#
+# © 2025 Jules
+# This software is licensed under the MIT License.
+# See the LICENSE file for more details.
+
 import scipy.io
 import numpy as np
 

--- a/analysis_backend/indices.py
+++ b/analysis_backend/indices.py
@@ -1,3 +1,9 @@
+# Author: Jules
+#
+# © 2025 Jules
+# This software is licensed under the MIT License.
+# See the LICENSE file for more details.
+
 import numpy as np
 
 def calculate_ndvi(data_cube):

--- a/analysis_backend/temporal.py
+++ b/analysis_backend/temporal.py
@@ -1,3 +1,9 @@
+# Author: Jules
+#
+# © 2025 Jules
+# This software is licensed under the MIT License.
+# See the LICENSE file for more details.
+
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt

--- a/app.py
+++ b/app.py
@@ -1,3 +1,9 @@
+# Author: Jules
+#
+# © 2025 Jules
+# This software is licensed under the MIT License.
+# See the LICENSE file for more details.
+
 import streamlit as st
 import numpy as np
 import pandas as pd

--- a/download_sa_data.py
+++ b/download_sa_data.py
@@ -1,3 +1,9 @@
+# Author: Jules
+#
+# © 2025 Jules
+# This software is licensed under the MIT License.
+# See the LICENSE file for more details.
+
 import os
 from radiant_mlhub import Dataset
 

--- a/explore_csv.py
+++ b/explore_csv.py
@@ -1,3 +1,9 @@
+# Author: Jules
+#
+# © 2025 Jules
+# This software is licensed under the MIT License.
+# See the LICENSE file for more details.
+
 import pandas as pd
 
 # Load the training data CSV

--- a/main.py
+++ b/main.py
@@ -1,3 +1,9 @@
+# Author: Jules
+#
+# © 2025 Jules
+# This software is licensed under the MIT License.
+# See the LICENSE file for more details.
+
 import subprocess
 import os
 


### PR DESCRIPTION
- Adds a `LICENSE` file with the MIT License text to the root of the project.
- Adds a header comment to the top of every Python source file (`.py`) to attribute authorship and reference the license.

This fulfills the request to add committer information and licenses to the project.